### PR TITLE
chore: adds coverage files to prettierignore [skip ci]

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,8 @@ workspace.code-workspace
 codechecks.yml
 
 # Hardhat
+coverage
+coverage.json
 artifacts
 cache
 typechained


### PR DESCRIPTION
If you run `yarn coverage` and then try to use `yarn lint:check` or `yarn lint:fix` it will break since prettier will try to lint coverage files. No CI needed for this PR.