### PR TITLE
ci: gas reporter configs improved

### DIFF
--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  unit:
+  run:
     runs-on: ubuntu-latest
     steps:
       - name: Check out github repository
@@ -35,8 +35,12 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Run gas tests
-        run: yarn test:gas && npx codechecks
+        run: yarn test:gas
         env:
           ETH_NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
+
+      - name: Run eth gas reporter
+        run: npx codechecks
+        env:
           COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
           CC_SECRET: ${{ secrets.CC }}

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -35,11 +35,8 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Run gas tests
-        run: yarn test:gas
+        run: yarn test:gas && npx codechecks
         env:
           ETH_NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
-
-      - name: Run eth gas reporter
-        run: npx codechecks
-        env:
+          COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
           CC_SECRET: ${{ secrets.CC }}

--- a/codechecks.yml
+++ b/codechecks.yml
@@ -1,2 +1,8 @@
 checks:
   - name: eth-gas-reporter/codechecks
+  
+settings:
+  speculativeBranchSelection: false
+  branches:
+    - main
+    - dev

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -71,6 +71,8 @@ const config: HardhatUserConfig = {
     currency: process.env.COINMARKETCAP_DEFAULT_CURRENCY || 'USD',
     coinmarketcap: process.env.COINMARKETCAP_API_KEY,
     enabled: process.env.REPORT_GAS ? true : false,
+    showMethodSig: true,
+    onlyCalledMethods: false,
   },
   preprocess: {
     eachLine: removeConsoleLog((hre) => hre.network.name !== 'hardhat'),


### PR DESCRIPTION
Improves gas reporter configuration, but also fixes CI for `main` branch that is currently broken. Making the report on the deltas by `gas reporter` not work in PRs.