### PR TITLE
fix: setBalance to allow less than 1000ETH

### DIFF
--- a/test/utils/contracts.ts
+++ b/test/utils/contracts.ts
@@ -19,5 +19,5 @@ export const deploy = async (contract: ContractFactory, args: any[]): Promise<{ 
 };
 
 export const setBalance = async (address: string, amount: BigNumber): Promise<void> => {
-  await network.provider.send('hardhat_setBalance', [address, amount.toHexString()]);
+  await network.provider.send('hardhat_setBalance', [address, amount.toHexString().replace('0x0', '0x')]);
 };


### PR DESCRIPTION
replacing leading 0s on QUANTITY to allow less than 1000ETH in `contracts.setBalance`
https://github.com/nomiclabs/hardhat/issues/1585