### PR TITLE
chore: removes prefix from node's uri

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-# network specific node uri: `"ETH_NODE_URI_" + networkName.toUpperCase()`
-ETH_NODE_URI_MAINNET=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
+# network specific node uri: `"NODE_URI_" + networkName.toUpperCase()`
+NODE_URI_MAINNET=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
 # generic node uri (if no specific found):
-ETH_NODE_URI=https://eth-{{networkName}}.infura.io/v3/<apiKey>
+NODE_URI=https://eth-{{networkName}}.infura.io/v3/<apiKey>
 
 # network specific mnemonic: `MNEMONIC_${networkName.toUpperCase()}`
 MNEMONIC_MAINNET=<mnemonic for mainnet>

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run gas tests
         run: yarn test:gas
         env:
-          ETH_NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
+          NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
 
       - name: Run eth gas reporter
         run: npx codechecks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Run e2e tests
         run: yarn test:e2e
         env:
-          ETH_NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
+          NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -2,23 +2,23 @@ import 'dotenv/config';
 
 export function getNodeUrl(networkName: string): string {
   if (networkName) {
-    const uri = process.env[`ETH_NODE_URI_${networkName.toUpperCase()}`];
+    const uri = process.env[`NODE_URI_${networkName.toUpperCase()}`];
     if (uri && uri !== '') {
       return uri;
     }
   }
 
   if (networkName === 'localhost') {
-    // do not use ETH_NODE_URI
+    // do not use NODE_URI
     return 'http://localhost:8545';
   }
 
-  let uri = process.env.ETH_NODE_URI;
+  let uri = process.env.NODE_URI;
   if (uri) {
     uri = uri.replace('{{networkName}}', networkName);
   }
   if (!uri || uri === '') {
-    // throw new Error(`environment variable "ETH_NODE_URI" not configured `);
+    // throw new Error(`environment variable "NODE_URI" not configured `);
     return '';
   }
   if (uri.indexOf('{{') >= 0) {


### PR DESCRIPTION
ETH_ prefix doesn't make any sense, since we could be using poly, or any other EVM chain. Also `ETH` is a currency, Ethereum is the network 👼🏽 