### PR TITLE
fix: use current block gas price

### DIFF
--- a/test/utils/behaviours.ts
+++ b/test/utils/behaviours.ts
@@ -198,6 +198,6 @@ export const fnShouldOnlyBeCallableByGovernance = (
   function callFunction(impersonator: Impersonator) {
     const argsArray: unknown[] = typeof args === 'function' ? args() : args;
     const fn = delayedContract().connect(impersonator)[fnName] as (...args: unknown[]) => unknown;
-    return fn(...argsArray, { gasPrice: 0 });
+    return fn(...argsArray);
   }
 };


### PR DESCRIPTION
Calling `fnShouldOnlyBeCallableByGovernance` in a test throws an error:

```
AssertionError: Expected transaction to be reverted with OnlyGovernance(), but other exception was thrown:
InvalidInputError: Transaction maxFeePerGas (0) is too low for the next block, which has a baseFeePerGas of 773119215
```

This happens because the function sends a tx with `{ gasPrice: 0 }`. Let's use the default price instead.