### PR TITLE
feat: adds files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,17 @@
       "url": "https://github.com/wei3erHase"
     }
   ],
+  "files": [
+    "solidity/contracts",
+    "solidity/interfaces",
+    "artifacts/solidity/**/*.json",
+    "!artifacts/solidity/**/**/*.dbg.json",
+    "typechained",
+    "deployments",
+    "!deployments/localhost",
+    "!.env",
+    "!**/.DS_Store"
+  ],
   "scripts": {
     "compile": "hardhat compile",
     "compile:test": "cross-env TEST=true hardhat compile",


### PR DESCRIPTION
When doing an `npm publish` this setup will:

**Include**
- typechained
- deployments
- artifacts
- smart contracts and interfaces

**Exclude**
- localhost deployments
- .env file
- .DS_STORE files
- *.dbg.json files