### PR TITLE
feat: adds eth-sdk to compile flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   ],
   "scripts": {
-    "compile": "hardhat compile",
+    "compile": "eth-sdk && hardhat compile",
     "compile:test": "cross-env TEST=true hardhat compile",
     "coverage": "hardhat coverage",
     "deploy": "npx hardhat deploy",


### PR DESCRIPTION
- adds eth-sdk to `yarn compile` since newbies don't understand that they need to execute `eth-sdk`. Also, they kinda go hand in hand.