### PR TITLE
feat: adds pre publish clean and compilation

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,7 +13,7 @@ import * as env from './utils/env';
 import 'tsconfig-paths/register';
 
 const networks: NetworksUserConfig =
-  env.isHardhatCompile() || env.isTesting()
+  env.isHardhatCompile() || env.isHardhatClean() || env.isTesting()
     ? {}
     : {
         hardhat: {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint:check": "cross-env solhint 'contracts/**/*.sol' 'interfaces/**/*.sol' && cross-env prettier --check './**'",
     "lint:fix": "sort-package-json && cross-env prettier --write './**' && cross-env solhint --fix 'contracts/**/*.sol' 'interfaces/**/*.sol'",
     "prepare": "husky install",
-    "prepublishOnly": "pinst --disable",
+    "prepublishOnly": "hardhat clean && hardhat compile && pinst --disable",
     "postpublish": "pinst --enable",
     "release": "standard-version",
     "test": "yarn compile:test && cross-env TEST=true mocha",

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -75,3 +75,7 @@ export function isTesting(): boolean {
 export function isHardhatCompile(): boolean {
   return process.argv[process.argv.length - 1] == 'compile';
 }
+
+export function isHardhatClean(): boolean {
+  return process.argv[process.argv.length - 1] == 'clean';
+}


### PR DESCRIPTION
**Why?**
Without this there is a possibility where you don't remember to clean artifacts (and therefore types) and publish an old version of both of them into your npm package (bad bad, not good).

We then will force the re-creation of artifacts and types before publishing to npm.