### PR TITLE
chore: mainnet to ethereum renaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,14 @@
 # network specific node uri: `"NODE_URI_" + networkName.toUpperCase()`
-NODE_URI_MAINNET=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
+NODE_URI_ETHEREUM=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
 
 # network specific account type: `${networkName.toUpperCase()}_ACCOUNTS_TYPE`, can either be MNEMONIC, or PRIVATE_KEYS.
-MAINNET_ACCOUNTS_TYPE=PRIVATE_KEYS
+ETHEREUM_ACCOUNTS_TYPE=PRIVATE_KEYS
 
 # network specific mnemonic: `${networkName.toUpperCase()}_MNEMONIC`
-MAINNET_MNEMONIC=<mnemonic for mainnet>
+ETHEREUM_MNEMONIC=<mnemonic for mainnet>
 
 # network specific private keys: `${networkName.toUpperCase()}_{INDEX_OF_ACCOUNT}_PRIVATE_KEY`
-MAINNET_1_PRIVATE_KEY=<private key for first mainnet account>
+ETHEREUM_1_PRIVATE_KEY=<private key for first mainnet account>
 
 # Encrypted credentials
 KMS_KEY_ID=
@@ -23,7 +23,7 @@ COINMARKETCAP_DEFAULT_CURRENCY=USD
 
 # Etherscan (optional, only for verifying smart contracts)
 # network specific api key: `${networkName.toUpperCase()}_{INDEX_OF_ACCOUNT}_PRIVATE_KEY`
-MAINNET_ETHERSCAN_API_KEY=
+ETHEREUM_ETHERSCAN_API_KEY=
 
 
 

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run gas tests
         run: yarn test:gas
         env:
-          NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
+          NODE_URI_ETHEREUM: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
 
       - name: Run eth gas reporter
         run: npx codechecks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Run e2e tests
         run: yarn test:e2e
         env:
-          NODE_URI_MAINNET: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}
+          NODE_URI_ETHEREUM: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMYKEY }}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,16 +19,16 @@ const networks: NetworksUserConfig =
         hardhat: {
           forking: {
             enabled: process.env.FORK ? true : false,
-            url: env.getNodeUrl('mainnet'),
+            url: env.getNodeUrl('ethereum'),
           },
         },
         kovan: {
           url: env.getNodeUrl('kovan'),
           accounts: env.getAccounts('kovan'),
         },
-        mainnet: {
-          url: env.getNodeUrl('mainnet'),
-          accounts: env.getAccounts('mainnet'),
+        ethereum: {
+          url: env.getNodeUrl('ethereum'),
+          accounts: env.getAccounts('ethereum'),
         },
       };
 
@@ -67,7 +67,7 @@ const config: HardhatUserConfig = {
     eachLine: removeConsoleLog((hre) => hre.network.name !== 'hardhat'),
   },
   etherscan: {
-    apiKey: env.getEtherscanAPIKeys(['mainnet']),
+    apiKey: env.getEtherscanAPIKeys(['ethereum']),
   },
   typechain: {
     outDir: 'typechained',

--- a/test/e2e/dai.spec.ts
+++ b/test/e2e/dai.spec.ts
@@ -22,7 +22,7 @@ describe('DAI @skip-on-coverage', () => {
   before(async () => {
     [stranger] = await ethers.getSigners();
     await evm.reset({
-      jsonRpcUrl: getNodeUrl('mainnet'),
+      jsonRpcUrl: getNodeUrl('ethereum'),
       blockNumber: forkBlockNumber.dai,
     });
 

--- a/utils/deploy.ts
+++ b/utils/deploy.ts
@@ -19,7 +19,7 @@ export const getChainId = async (hre: HardhatRuntimeEnvironment): Promise<number
 
 export const getRealChainIdOfFork = (hre: HardhatRuntimeEnvironment): number => {
   const config = hre.network.config as HardhatNetworkUserConfig;
-  if (config.forking?.url.includes('mainnet')) return 1;
+  if (config.forking?.url.includes('eth')) return 1;
   if (config.forking?.url.includes('ftm') || config.forking?.url.includes('fantom')) return 250;
   if (config.forking?.url.includes('polygon')) return 137;
   throw new Error('Should specify chain id of fork');


### PR DESCRIPTION
Renaming `mainnet` to `ethereum` since `mainnet` just means 'not testnet', and there are mainnets of polygon, fantom, avax, etc.