### PR TITLE
feat: add more ts paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
+      "@artifacts": ["artifacts/*"],
+      "@deploy": ["deploy/*"],
+      "@deployments": ["deployments/*"],
       "@typechained": ["typechained/index"],
       "@utils": ["test/utils/index"],
       "@utils/*": ["test/utils/*"],


### PR DESCRIPTION
Adds paths that already are on the scaffolding. More contentious might be `@deploy` but if you are doing complex deployment scripts, is a must-go imho.