### PR TITLE
fix: prettier on json and ignore yml files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,9 @@ workspace.code-workspace
 .DS_STORE
 codechecks.yml
 
+# CI
+.github/workflows
+
 # Hardhat
 coverage
 coverage.json

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:unit:parallel": "yarn test:parallel 'test/unit/**/*.spec.ts'"
   },
   "lint-staged": {
-    "*.{js,css,md,ts,sol}": "prettier --write",
+    "*.{js,css,md,ts,sol,json}": "prettier --write",
     "*.sol": "cross-env solhint --fix 'contracts/**/*.sol' 'interfaces/**/*.sol'",
     "package.json": "sort-package-json"
   },


### PR DESCRIPTION
Ignore `.yml` files on github workflows, and start linting `jsons` via `lint-staged`