### PR TITLE
fix: eth-sdk path to cjs

### DIFF
--- a/test/e2e/dai.spec.ts
+++ b/test/e2e/dai.spec.ts
@@ -10,7 +10,6 @@ import { expect } from 'chai';
 import { getNodeUrl } from 'utils/env';
 import forkBlockNumber from './fork-block-numbers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { Dai__factory } from '@eth-sdk-types';
 
 const daiWhaleAddress = '0x16463c0fdb6ba9618909f5b120ea1581618c1b9e';
 
@@ -30,7 +29,6 @@ describe('DAI @skip-on-coverage', () => {
     const sdk = getMainnetSdk(stranger);
     dai = sdk.dai;
 
-    console.log(Dai__factory.abi);
     daiWhale = await wallet.impersonate(daiWhaleAddress);
     snapshotId = await evm.snapshot.take();
   });

--- a/test/e2e/dai.spec.ts
+++ b/test/e2e/dai.spec.ts
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 import { getNodeUrl } from 'utils/env';
 import forkBlockNumber from './fork-block-numbers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { Dai__factory } from '@eth-sdk-types';
 
 const daiWhaleAddress = '0x16463c0fdb6ba9618909f5b120ea1581618c1b9e';
 
@@ -29,6 +30,7 @@ describe('DAI @skip-on-coverage', () => {
     const sdk = getMainnetSdk(stranger);
     dai = sdk.dai;
 
+    console.log(Dai__factory.abi);
     daiWhale = await wallet.impersonate(daiWhaleAddress);
     snapshotId = await evm.snapshot.take();
   });

--- a/test/unit/Greeter.spec.ts
+++ b/test/unit/Greeter.spec.ts
@@ -13,7 +13,7 @@ describe('Greeter', () => {
   before(async () => {
     greeterFactory = await smock.mock<Greeter__factory>('Greeter');
     greeter = await greeterFactory.deploy('Hello, world!');
-
+    console.log(Greeter__factory.abi);
     snapshotId = await evm.snapshot.take();
   });
 

--- a/test/unit/Greeter.spec.ts
+++ b/test/unit/Greeter.spec.ts
@@ -13,7 +13,6 @@ describe('Greeter', () => {
   before(async () => {
     greeterFactory = await smock.mock<Greeter__factory>('Greeter');
     greeter = await greeterFactory.deploy('Hello, world!');
-    console.log(Greeter__factory.abi);
     snapshotId = await evm.snapshot.take();
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
       "@utils/*": ["test/utils/*"],
       "@e2e/*": ["test/e2e/*"],
       "@unit/*": ["test/unit/*"],
-      "@eth-sdk-types": ["node_modules/.dethcrypto/eth-sdk-client/esm/types"]
+      "@eth-sdk-types": ["node_modules/.dethcrypto/eth-sdk-client/cjs/types"]
     }
   },
   "include": ["./scripts", "./deploy", "./test"],


### PR DESCRIPTION
TS config path to eth-sdk uses `esm` as default, if you try to import anything `esm` it will brake since the `tsconfig` is set up to `commonjs` (because if not hardhat wont work).