### PR TITLE
fix: etherscan api key for ethereum

### DIFF
--- a/utils/deploy.ts
+++ b/utils/deploy.ts
@@ -14,7 +14,7 @@ export const getChainId = async (hre: HardhatRuntimeEnvironment): Promise<number
     return testChainId;
   }
   if (!!process.env.FORK) return getRealChainIdOfFork(hre);
-  return await (hre as any).getChainId();
+  return parseInt(await hre.getChainId());
 };
 
 export const getRealChainIdOfFork = (hre: HardhatRuntimeEnvironment): number => {

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -62,7 +62,7 @@ export function getEtherscanAPIKeys(networks: string[]): { [network: string]: st
     if (!networkApiKey) {
       console.warn(`No etherscan api key for ${network}`);
     } else {
-      apiKeys[network] = networkApiKey;
+      apiKeys[network == 'ethereum' ? 'mainnet' : network] = networkApiKey;
     }
   });
   return apiKeys;


### PR DESCRIPTION
Sadly etherscan plugin uses `mainnet` name for `ethereum` 😞  - this fixes it.