### PR TITLE
fix: greeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ This is achieved using several hardhat plugins, and external known packages.
 
 ---
 
+## Setup
+
+```bash
+# Install dependencies
+yarn install
+# Copy Env example file
+cp .env.example .env
+```
+
+After installing dependencies and copying the example environment, you will have to update your `.env` file with
+at least you alchemy API KEY (`NODE_URI_ETHEREUM`).
+<br/>
+You can generate your API KEY in the [Alchemy site](https://www.alchemy.com).
+
+---
+
 ## Tools
 
 This boilerplate includes:
@@ -62,7 +78,7 @@ Runs tests that should be run in mainnet's fork.
 ### **Lint**
 
 ```bash
-yarn lint
+yarn lint:check
 ```
 
 Runs solhint.

--- a/deploy/001_deploy.ts
+++ b/deploy/001_deploy.ts
@@ -5,6 +5,7 @@ import { getChainId, shouldVerifyContract } from '../utils/deploy';
 export const INITIAL_GREET: { [chainId: string]: string } = {
   '1': 'Halo!',
   '137': 'Halo to polygon network!',
+  '31337': 'Hello',
 };
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -13,7 +14,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
   const chainId = await getChainId(hre);
 
   const deploy = await hre.deployments.deploy('Greeter', {
-    contract: 'contracts/Greeter.sol:Greeter',
+    contract: 'solidity/contracts/Greeter.sol:Greeter',
     from: deployer,
     args: [INITIAL_GREET[chainId]],
     log: true,

--- a/test/unit/Greeter.spec.ts
+++ b/test/unit/Greeter.spec.ts
@@ -29,8 +29,8 @@ describe('Greeter', () => {
   it('should return the new greeting once is changed', async () => {
     expect(await greeter.greet()).to.equal('Hello, world!');
 
-    await greeter.setGreeting('Hello, world!');
-    expect(await greeter.greet()).to.equal('Hello, world!');
+    await greeter.setGreeting('Hola, mundo!');
+    expect(await greeter.greet()).to.equal('Hola, mundo!');
   });
 
   it('should revert if greeting is empty', async () => {


### PR DESCRIPTION
- Fix greeter deployer on hardhat network
- Fix greeter deployer contracts path
- Update docs for env and setup info

Now you should be able to run `yarn hardhat node` out of the box without errors