### PR TITLE
refactor: uses hardhat network helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@defi-wonderland/smock": "2.0.7",
     "@dethcrypto/eth-sdk": "0.3.3",
     "@dethcrypto/eth-sdk-client": "0.1.6",
+    "@nomicfoundation/hardhat-network-helpers": "1.0.0",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "3.1.0",
     "@nomiclabs/hardhat-waffle": "2.0.3",

--- a/test/e2e/dai.spec.ts
+++ b/test/e2e/dai.spec.ts
@@ -1,4 +1,5 @@
 import { getMainnetSdk } from '@dethcrypto/eth-sdk-client';
+import helpers, { SnapshotRestorer } from '@nomicfoundation/hardhat-network-helpers';
 import { Dai } from '@eth-sdk-types';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { JsonRpcSigner } from '@ethersproject/providers';
@@ -17,7 +18,7 @@ describe('DAI @skip-on-coverage', () => {
   let stranger: SignerWithAddress;
   let daiWhale: JsonRpcSigner;
   let dai: Dai;
-  let snapshotId: string;
+  let snapshot: SnapshotRestorer;
 
   before(async () => {
     [stranger] = await ethers.getSigners();
@@ -30,11 +31,11 @@ describe('DAI @skip-on-coverage', () => {
     dai = sdk.dai;
 
     daiWhale = await wallet.impersonate(daiWhaleAddress);
-    snapshotId = await evm.snapshot.take();
+    snapshot = await helpers.takeSnapshot();
   });
 
   beforeEach(async () => {
-    await evm.snapshot.revert(snapshotId);
+    await snapshot.restore();
   });
 
   describe('transfer', () => {

--- a/test/unit/Greeter.spec.ts
+++ b/test/unit/Greeter.spec.ts
@@ -1,23 +1,23 @@
 import chai, { expect } from 'chai';
+import helpers, { SnapshotRestorer } from '@nomicfoundation/hardhat-network-helpers';
 import { MockContract, MockContractFactory, smock } from '@defi-wonderland/smock';
 import { Greeter, Greeter__factory } from '@typechained';
-import { evm } from '@utils';
 
 chai.use(smock.matchers);
 
 describe('Greeter', () => {
   let greeter: MockContract<Greeter>;
   let greeterFactory: MockContractFactory<Greeter__factory>;
-  let snapshotId: string;
+  let snapshot: SnapshotRestorer;
 
   before(async () => {
     greeterFactory = await smock.mock<Greeter__factory>('Greeter');
     greeter = await greeterFactory.deploy('Hello, world!');
-    snapshotId = await evm.snapshot.take();
+    snapshot = await helpers.takeSnapshot();
   });
 
   beforeEach(async () => {
-    await evm.snapshot.revert(snapshotId);
+    await snapshot.restore();
   });
 
   it('should return current greeting', async () => {

--- a/test/utils/evm.ts
+++ b/test/utils/evm.ts
@@ -1,37 +1,4 @@
-import { BigNumber, BigNumberish } from 'ethers';
 import { network } from 'hardhat';
-
-export const advanceTimeAndBlock = async (time: number): Promise<void> => {
-  await advanceTime(time);
-  await advanceBlocks(1);
-};
-
-export const advanceToTimeAndBlock = async (time: number): Promise<void> => {
-  await advanceToTime(time);
-  await advanceBlocks(1);
-};
-
-export const advanceTime = async (time: number): Promise<void> => {
-  await network.provider.request({
-    method: 'evm_increaseTime',
-    params: [time],
-  });
-};
-
-export const advanceToTime = async (time: number): Promise<void> => {
-  await network.provider.request({
-    method: 'evm_setNextBlockTimestamp',
-    params: [time],
-  });
-};
-
-export const advanceBlocks = async (blocks: BigNumberish) => {
-  blocks = !BigNumber.isBigNumber(blocks) ? BigNumber.from(`${blocks}`) : blocks;
-  await network.provider.request({
-    method: 'hardhat_mine',
-    params: [blocks.toHexString().replace('0x0', '0x')],
-  });
-};
 
 export const reset = async (forking?: { [key: string]: any }) => {
   const params = forking ? [{ forking }] : [];
@@ -40,34 +7,3 @@ export const reset = async (forking?: { [key: string]: any }) => {
     params,
   });
 };
-
-class SnapshotManager {
-  snapshots: { [id: string]: string } = {};
-
-  async take(): Promise<string> {
-    const id = await this.takeSnapshot();
-    this.snapshots[id] = id;
-    return id;
-  }
-
-  async revert(id: string): Promise<void> {
-    await this.revertSnapshot(this.snapshots[id]);
-    this.snapshots[id] = await this.takeSnapshot();
-  }
-
-  private async takeSnapshot(): Promise<string> {
-    return (await network.provider.request({
-      method: 'evm_snapshot',
-      params: [],
-    })) as string;
-  }
-
-  private async revertSnapshot(id: string) {
-    await network.provider.request({
-      method: 'evm_revert',
-      params: [id],
-    });
-  }
-}
-
-export const snapshot = new SnapshotManager();

--- a/test/utils/wallet.ts
+++ b/test/utils/wallet.ts
@@ -1,28 +1,19 @@
-import { BigNumber, constants, Wallet } from 'ethers';
-import { ethers, network } from 'hardhat';
+import { constants, Wallet } from 'ethers';
+import { ethers } from 'hardhat';
 import { JsonRpcSigner } from '@ethersproject/providers';
 import { getAddress } from 'ethers/lib/utils';
 import { randomHex } from 'web3-utils';
+import { impersonateAccount, setBalance } from '@nomicfoundation/hardhat-network-helpers';
 
 export const impersonate = async (address: string): Promise<JsonRpcSigner> => {
-  await network.provider.request({
-    method: 'hardhat_impersonateAccount',
-    params: [address],
-  });
+  await impersonateAccount(getAddress(address));
   return ethers.provider.getSigner(address);
 };
 
 export const generateRandom = async () => {
   const wallet = (await Wallet.createRandom()).connect(ethers.provider);
-  await setBalance({
-    account: wallet.address,
-    balance: constants.MaxUint256,
-  });
+  await setBalance(wallet.address, constants.MaxUint256);
   return wallet;
-};
-
-export const setBalance = async ({ account, balance }: { account: string; balance: BigNumber }): Promise<void> => {
-  await ethers.provider.send('hardhat_setBalance', [account, balance.toHexString().replace('0x0', '0x')]);
 };
 
 export const generateRandomAddress = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@nomicfoundation/hardhat-network-helpers@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.0.tgz#6e33eb25c9dd0e2e27adb8b55ae0dae0414bf6e0"
+  integrity sha512-7ThZworz1ECYhoGsLbnZJgioErNLhzegxafTmOr5jITs5AcsbyOuJtJgmXfRTYwEkt94FL8sxZilgOUTACl0Vg==
+  dependencies:
+    ethereumjs-util "^7.1.4"
+
 "@nomiclabs/ethereumjs-vm@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.2.tgz#2f8817113ca0fb6c44c1b870d0a809f0e026a6cc"


### PR DESCRIPTION
We are starting to leverage the newly released npm package from hardhat that basically makes it easier to do all the stuff that we had on our tooling already.